### PR TITLE
Add ability to turn on/off skip_translate

### DIFF
--- a/app/controllers/alchemy/admin/contents_controller.rb
+++ b/app/controllers/alchemy/admin/contents_controller.rb
@@ -50,7 +50,7 @@ module Alchemy
       private
 
       def content_params
-        params.require(:content).permit(:element_id, :name, :ingredient, :essence_type)
+        params.require(:content).permit(:element_id, :name, :ingredient, :essence_type, :skip_translate)
       end
 
       def picture_gallery_editor?

--- a/app/controllers/alchemy/admin/contents_controller.rb
+++ b/app/controllers/alchemy/admin/contents_controller.rb
@@ -50,7 +50,7 @@ module Alchemy
       private
 
       def content_params
-        params.require(:content).permit(:element_id, :name, :ingredient, :essence_type, :skip_translate)
+        params.require(:content).permit(:element_id, :name, :ingredient, :essence_type)
       end
 
       def picture_gallery_editor?

--- a/app/controllers/alchemy/admin/elements_controller.rb
+++ b/app/controllers/alchemy/admin/elements_controller.rb
@@ -121,6 +121,7 @@ module Alchemy
 
         element.essences.each do |essence|
           next unless [Alchemy::EssenceText,Alchemy::EssenceRichtext,Alchemy::EssenceHtml].include? essence.class
+          next unless essence.content.translate
           position = essence.element.position
           key = "#{essence.content.name}_pos_#{position}"
 

--- a/app/controllers/alchemy/admin/elements_controller.rb
+++ b/app/controllers/alchemy/admin/elements_controller.rb
@@ -195,7 +195,7 @@ module Alchemy
       end
 
       def contents_params
-       params.fetch(:contents, {}).permit!
+        params.fetch(:contents, {}).permit!
       end
 
       def element_params

--- a/app/controllers/alchemy/admin/elements_controller.rb
+++ b/app/controllers/alchemy/admin/elements_controller.rb
@@ -72,14 +72,13 @@ module Alchemy
       # And update all contents in the elements by calling update_contents.
       #
       def update
-        # binding.pry
         if @element.update_contents(contents_params)
           @page = @element.page
           @element_validated = @element.update_attributes!(element_params)
 
           Rails.logger.error "[ALCHEMY_LOCALE] updating contents for element in elements_controller#update: #{@element}"
           update_translations(@element) if @element.page.language.language_code == 'en'
-          update_skip_translate(params)
+          update_skip_translate(params[:skip_translate])
         else
           @element_validated = false
           @notice = _t('Validation failed')
@@ -140,10 +139,11 @@ module Alchemy
         Alchemy::TranslationSentEmail.new.perform(Localeapp.missing_translations.to_send.to_json)
       end
 
-      def update_skip_translate(params)
-        content_id = params[:contents].keys[0]
-        content = Alchemy::Content.find content_id
-        content.update(skip_translate: params[:skip_translate])
+      def update_skip_translate(skip_translate_hash)
+        skip_translate_hash.each do |content_id, value|
+          content = Alchemy::Content.find content_id
+          content.update(skip_translate: value)
+        end
       end
 
       def load_element

--- a/app/controllers/alchemy/admin/elements_controller.rb
+++ b/app/controllers/alchemy/admin/elements_controller.rb
@@ -121,7 +121,7 @@ module Alchemy
 
         element.essences.each do |essence|
           next unless [Alchemy::EssenceText,Alchemy::EssenceRichtext,Alchemy::EssenceHtml].include? essence.class
-          next unless essence.content.translate
+          next if essence.content.skip_translate
           position = essence.element.position
           key = "#{essence.content.name}_pos_#{position}"
 

--- a/app/controllers/alchemy/admin/elements_controller.rb
+++ b/app/controllers/alchemy/admin/elements_controller.rb
@@ -195,8 +195,7 @@ module Alchemy
       end
 
       def contents_params
-        cp = params.fetch(:contents, {}).permit!
-        cp.merge(skip_translate: params[:skip_translate])
+       params.fetch(:contents, {}).permit!
       end
 
       def element_params

--- a/app/models/alchemy/content/factory.rb
+++ b/app/models/alchemy/content/factory.rb
@@ -19,7 +19,8 @@ module Alchemy
         if (description = content_description(element, essence_hash)).blank?
           raise ContentDefinitionError, "No description found in elements.yml for #{essence_hash.inspect} and #{element.inspect}"
         else
-          new(name: description['name'], element_id: element.id)
+          translate = description['translate'] == false ? false : true
+          new(name: description['name'], element_id: element.id, translate: translate)
         end
       end
 

--- a/app/models/alchemy/content/factory.rb
+++ b/app/models/alchemy/content/factory.rb
@@ -19,8 +19,7 @@ module Alchemy
         if (description = content_description(element, essence_hash)).blank?
           raise ContentDefinitionError, "No description found in elements.yml for #{essence_hash.inspect} and #{element.inspect}"
         else
-          translate = description['translate'] == false ? false : true
-          new(name: description['name'], element_id: element.id, translate: translate)
+          new(name: description['name'], element_id: element.id, skip_translate: description['translate'] == false)
         end
       end
 

--- a/app/models/alchemy/translations/essence_body_updater.rb
+++ b/app/models/alchemy/translations/essence_body_updater.rb
@@ -41,7 +41,7 @@ module Alchemy
                 Rails.logger.error "PROBLEM finding content for content_id #{content_id} : #{essence_key} (locale: #{locale})"
                 nil
               end
-              if content && content.essence && content.translate
+              if content && content.essence && !content.skip_translate
                 content.essence.update_column(:body, translation)
                 if content.essence.kind_of? Alchemy::EssenceRichtext
                   content.essence.send(:strip_content)

--- a/app/models/alchemy/translations/essence_body_updater.rb
+++ b/app/models/alchemy/translations/essence_body_updater.rb
@@ -41,7 +41,7 @@ module Alchemy
                 Rails.logger.error "PROBLEM finding content for content_id #{content_id} : #{essence_key} (locale: #{locale})"
                 nil
               end
-              if content && content.essence
+              if content && content.essence && content.translate
                 content.essence.update_column(:body, translation)
                 if content.essence.kind_of? Alchemy::EssenceRichtext
                   content.essence.send(:strip_content)

--- a/app/views/alchemy/essences/_essence_html_editor.html.erb
+++ b/app/views/alchemy/essences/_essence_html_editor.html.erb
@@ -6,5 +6,7 @@
     content.ingredient
       ) %>
   <%= render 'alchemy/essences/shared/locale_links', content: content %>
+  <br>
+  <%= render 'alchemy/essences/shared/translate_essence_selector', content: content %>
 </div>
 <% end %>

--- a/app/views/alchemy/essences/_essence_richtext_editor.html.erb
+++ b/app/views/alchemy/essences/_essence_richtext_editor.html.erb
@@ -10,5 +10,7 @@
     ) %>
   </div>
   <%= render 'alchemy/essences/shared/locale_links', content: content %>
+  <br>
+  <%= render 'alchemy/essences/shared/translate_essence_selector', content: content %>
 </div>
 <% end -%>

--- a/app/views/alchemy/essences/_essence_text_editor.html.erb
+++ b/app/views/alchemy/essences/_essence_text_editor.html.erb
@@ -15,5 +15,7 @@
       <%= render 'alchemy/essences/shared/linkable_essence_tools', content: content %>
     <% end %>
     <%= render 'alchemy/essences/shared/locale_links', content: content %>
+    <br>
+    Translate essence: <%= radio_button_tag(:skip_translate, "true", content.skip_translate == true) %> <%= label_tag('true', "Off") %> | <%= radio_button_tag(:skip_translate, "false", content.skip_translate == false) %> <%= label_tag('false', "On") %>
   </div>
 <% end %>

--- a/app/views/alchemy/essences/_essence_text_editor.html.erb
+++ b/app/views/alchemy/essences/_essence_text_editor.html.erb
@@ -16,6 +16,6 @@
     <% end %>
     <%= render 'alchemy/essences/shared/locale_links', content: content %>
     <br>
-    Translate essence: <%= radio_button_tag(:skip_translate, "true", content.skip_translate == true) %> <%= label_tag('true', "Off") %> | <%= radio_button_tag(:skip_translate, "false", content.skip_translate == false) %> <%= label_tag('false', "On") %>
+    <%= render 'alchemy/essences/shared/translate_essence_selector', content: content %>
   </div>
 <% end %>

--- a/app/views/alchemy/essences/shared/_translate_essence_selector.html.erb
+++ b/app/views/alchemy/essences/shared/_translate_essence_selector.html.erb
@@ -1,0 +1,5 @@
+Translate essence:
+<%= radio_button_tag("skip_translate[#{content.id}]", "true", content.skip_translate == true) %> 
+<%= label_tag('true', "Off", class: 'inline') %> 
+<%= radio_button_tag("skip_translate[#{content.id}]", "false", content.skip_translate == false) %> 
+<%= label_tag('false', "On", class: 'inline') %>

--- a/app/views/alchemy/essences/shared/_translate_essence_selector.html.erb
+++ b/app/views/alchemy/essences/shared/_translate_essence_selector.html.erb
@@ -1,5 +1,5 @@
 Translate essence:
 <%= radio_button_tag("skip_translate[#{content.id}]", "true", content.skip_translate == true) %> 
 <%= label_tag('true', "Off", class: 'inline') %> 
-<%= radio_button_tag("skip_translate[#{content.id}]", "false", content.skip_translate == false) %> 
+<%= radio_button_tag("skip_translate[#{content.id}]", "false", content.skip_translate == false || content.skip_translate.nil?) %> 
 <%= label_tag('false', "On", class: 'inline') %>


### PR DESCRIPTION
jira: https://agile.lootcrate.com/browse/SCE-39

why: need ability to turn translate option on if so desired.  PR https://github.com/jsqu99/alchemy_cms/pull/3 sets skip translate in `elements.yml.`

this pr: adds radio button selector to alchemy essences in alchemy editor
