### PR TITLE
minor updates to languages section

### DIFF
--- a/app/helpers/alchemy/admin/contents_helper.rb
+++ b/app/helpers/alchemy/admin/contents_helper.rb
@@ -115,10 +115,7 @@ module Alchemy
             end
           end
         end
-        if links.present?
-          link_string = links.join(' | ')
-        end
-        'Other translations: ' + link_string
+        links.present? ? "Other translations: #{links.join(' | ')}" : ""
       end
 
       # Renders a link for removing that content

--- a/app/helpers/alchemy/admin/contents_helper.rb
+++ b/app/helpers/alchemy/admin/contents_helper.rb
@@ -116,10 +116,9 @@ module Alchemy
           end
         end
         if links.present?
-          links.unshift('Other translations:')
+          link_string = links.join(' | ')
         end
-        links.join(' | ')
-
+        'Other translations: ' + link_string
       end
 
       # Renders a link for removing that content

--- a/app/views/alchemy/essences/shared/_translate_essence_selector.html.erb
+++ b/app/views/alchemy/essences/shared/_translate_essence_selector.html.erb
@@ -1,5 +1,5 @@
-Translate essence:
+Translate?:
 <%= radio_button_tag("skip_translate[#{content.id}]", "true", content.skip_translate == true) %> 
-<%= label_tag('true', "Off", class: 'inline') %> 
+<%= label_tag('true', "No", class: 'inline') %> 
 <%= radio_button_tag("skip_translate[#{content.id}]", "false", content.skip_translate == false || content.skip_translate.nil?) %> 
-<%= label_tag('false', "On", class: 'inline') %>
+<%= label_tag('false', "Yes", class: 'inline') %>


### PR DESCRIPTION
changes wording on do not translate link.
removes `|` from start of other languages link
