### PR TITLE
SCE-117 add ability to skip certain pages on language tree copy

### DIFF
--- a/alchemy_cms.gemspec
+++ b/alchemy_cms.gemspec
@@ -38,7 +38,7 @@ Gem::Specification.new do |gem|
   gem.add_runtime_dependency 'responders',                       ['~> 2.0']
   gem.add_runtime_dependency 'sass-rails',                       ['~> 5.0']
   gem.add_runtime_dependency 'sassy-buttons',                    ['~> 0.2.6']
-  gem.add_runtime_dependency 'select2-rails',                    ['>= 3.5.9.1', '< 4.0']
+  gem.add_runtime_dependency 'select2-rails',                    ['~> 4.0']
   gem.add_runtime_dependency 'simple_form',                      ['~> 3.0']
   gem.add_runtime_dependency 'spinner.rb'
   gem.add_runtime_dependency 'turbolinks',                       ['~> 2.5']

--- a/app/controllers/alchemy/admin/elements_controller.rb
+++ b/app/controllers/alchemy/admin/elements_controller.rb
@@ -123,8 +123,8 @@ module Alchemy
         element.essences.each do |essence|
           next unless [Alchemy::EssenceText,Alchemy::EssenceRichtext,Alchemy::EssenceHtml].include? essence.class
           next if essence.content.skip_translate
-          position = essence.element.position
-          key = "#{essence.content.name}_pos_#{position}"
+          key_gen = Alchemy::Translations::HashKeyGenerator.new(essence.content)
+          key = key_gen.generate
 
           description = essence.body
 

--- a/app/helpers/alchemy/admin/contents_helper.rb
+++ b/app/helpers/alchemy/admin/contents_helper.rb
@@ -94,8 +94,8 @@ module Alchemy
         links = []
 
         if h = Alchemy::Translations::Cacher.new.all_translated_content
-          position = content.essence.element.position
-          key = "#{content.name}_pos_#{position}"
+          key_gen = Alchemy::Translations::HashKeyGenerator.new(content)
+          key = key_gen.generate
 
           if h[key]
             # now what locales do we have for this content?

--- a/app/models/alchemy/page.rb
+++ b/app/models/alchemy/page.rb
@@ -321,8 +321,10 @@ module Alchemy
     end
 
     def copy_children_to(new_parent)
+      skip_pages = Alchemy::SkipCopyPage.pluck(:page_id)
       self.children.each do |child|
         next if child == new_parent
+        next if skip_pages.include?(child.id)
         new_child = Page.copy(child, {
           :language_id => new_parent.language_id,
           :language_code => new_parent.language_code

--- a/app/models/alchemy/translations/cacher.rb
+++ b/app/models/alchemy/translations/cacher.rb
@@ -18,8 +18,8 @@ module Alchemy
                                   t[:essence_type].eq('Alchemy::EssenceHtml'))).each do |content|
 
             begin
-              position = content.essence.element.position
-              key = "#{content.name}_pos_#{position}"
+              key_gen = Alchemy::Translations::HashKeyGenerator.new(content)
+              key = key_gen.generate
               data[key] ||= {}
               data[key][content.essence.element.page.language.language_code] = content.id
             rescue => e

--- a/app/models/alchemy/translations/hash_key_generator.rb
+++ b/app/models/alchemy/translations/hash_key_generator.rb
@@ -1,0 +1,15 @@
+module Alchemy
+  module Translations
+    class HashKeyGenerator
+      def initialize(content)
+        @content = content
+      end
+      def generate
+        element = @content.essence.element
+        page = element.page.name
+        position = element.position
+        "#{page}_#{@content.name}_pos_#{position}"
+      end
+    end
+  end
+end


### PR DESCRIPTION
### jira:

https://agile.lootcrate.com/browse/SCE-117
### why:
- When a user attempts to copy the English Language Tree to a new language in Alchemy CMS, the system times out while copying the `contest winners` page.
### this PR:

Adds ability to skip a certain page.  Requires LC PR: https://github.com/LootCrate/lootcrate/pull/3881
