### PR TITLE
SCE-214 Fix name error schedule publish

### DIFF
--- a/app/controllers/alchemy/admin/pages_controller.rb
+++ b/app/controllers/alchemy/admin/pages_controller.rb
@@ -1,6 +1,7 @@
 module Alchemy
   module Admin
     class PagesController < Alchemy::Admin::BaseController
+      require 'sidekiq/api'
       helper 'alchemy/pages'
 
       before_action :set_translation,


### PR DESCRIPTION
JIRA: https://agile.lootcrate.com/browse/SCE-214

Per Sidekiq docs: `sidekiq/api` is no longer automatically required.  If your code uses the API, you will need to require it.  Several schedule publish methods utilize the `sidekiq/api`  See: https://github.com/mperham/sidekiq/commit/0d2904a7a5e8508018c5d99f73c96d5b343202f0
